### PR TITLE
Add stillworks to Related Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Looking for something specific? These searches might help:
 - **Free LLM API for Europe** → see [Mistral AI](#mistral-ai) (EU-based, no region block)
 - **Free Llama API** → Groq, Cerebras, OpenRouter, GitHub Models all offer free Llama 3.3 70B
 - **Free DeepSeek API** → OpenRouter, Kluster AI, LLM7.io, GitHub Models
+- **Which keyless endpoints are answering right now** → [stillworks](https://stillworks.supercapybara.com) — Directories list. We check. Endpoints probed on a schedule with a real chat completion, failures published next to the successes
 
 ---
 


### PR DESCRIPTION
Adds one line to **Related Resources**. No provider entry is added — stillworks is not a provider, so it does
not belong in the provider tables.

```
- **Which keyless endpoints are answering right now** → [stillworks](https://stillworks.supercapybara.com) — Directories list. We check. Endpoints probed on a schedule with a real chat completion, failures published next to the successes
```

**What it is:** a registry of LLM endpoints where every row was produced by a real chat completion sent on a
schedule, not by reading a provider's docs. 19 endpoints currently answer with no `Authorization` header at
all; another 46 are free-tier-with-key, kept in the same table but labelled. `GET /api/llm/up` returns them
ranked, so `models[0]` is the pick and the rest are fallbacks. Capability flags (`tools`, `json_schema`,
`json_object`, `vision`) are listed as `proved` only when a real call demonstrated them; provider claims that
could not be reproduced sit in `claimed_unproved`.

**Why here:** this list answers "what free APIs exist and what are the published limits". This answers the
next question — which of them replied to an actual request today. It complements the tables rather than
duplicating them.

**What it does not claim:** it cannot tell a reader what their own IP's quota is — keyless quotas are commonly
per-IP, so an endpoint verified from the service's address can still return 402/429 from yours. Rows probed
with the project's own free-tier key prove only that the endpoint answered that account. It is a young project
with a small number of endpoints. All of this is printed on the page and in the API response.

MIT licensed, source at https://github.com/bon5co/stillworks

Disclosure: I work on stillworks — this is a self-submission, not a third-party recommendation. Happy to drop
the line if you would rather keep Related Resources to internal anchors only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added stillworks to the README Related Resources section.
- No provider was added or changed.
- No rate limits, speed tier, or OpenAI compatibility fields apply because stillworks is a resource directory.

| Change Type | Provider | Details |
|---|---|---|
| Structural change | stillworks | Added a link to a registry of verified keyless and free-tier LLM endpoints. |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->